### PR TITLE
Use path instead of absolutePath for resources

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -793,7 +793,7 @@ public class Main {
     private void parseDefaultPropertyFileFromResource(File potentialPropertyFile) throws IOException,
             CommandLineParsingException {
         try (InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream
-                (potentialPropertyFile.getAbsolutePath())) {
+                (potentialPropertyFile.getPath())) {
             if (resourceAsStream != null) {
                 parsePropertiesFile(resourceAsStream);
             }


### PR DESCRIPTION
## Environment

**Liquibase Version**: 4.5.0
**Liquibase Integration & Version**: CLI

## Pull Request Type

[x] Bug fix (fixes #2121)

## Description

When trying to read properties files from the class path, `file.getAbsolutePath()` is used. The result is some absolute path which won't exist in the classpath on most systems.

## Steps To Reproduce

See the description in issue #2121